### PR TITLE
Fix: Apply format selection for audio downloads (MP3/M4A)

### DIFF
--- a/Vividl/Model/DownloadConfigurations.cs
+++ b/Vividl/Model/DownloadConfigurations.cs
@@ -8,10 +8,17 @@ namespace Vividl.Model
     {
         public static OptionSet ApplyForAudioDownload(DownloadOption download, OptionSet options)
         {
+            options = options ?? new OptionSet();
+            
+            // Apply format selection for all audio downloads
+            if (!string.IsNullOrEmpty(download.FormatSelection))
+            {
+                options.Format = download.FormatSelection;
+            }
+            
             // When converting to mp3, add thumbnail.
             if (Settings.Default.AddMetadata && download.GetExt(defaultValue: "") == "mp3")
             {
-                options = options ?? new OptionSet();
                 options.EmbedThumbnail = true;
                 // This ensures thumbnails are correctly shown on Windows.
                 options.PostprocessorArgs = "-id3v2_version 3";


### PR DESCRIPTION
This fixes an issue where audio downloads would not start because the FormatSelection property was not being applied to the OptionSet passed to yt-dlp.

The ApplyForAudioDownload method now properly sets options.Format with the download's FormatSelection value, ensuring user-selected audio formats are correctly passed to yt-dlp through YoutubeDLSharp.

Fixes audio downloads for MP3, M4A, WAV, and Vorbis formats.